### PR TITLE
Minor improvements to OTP screen

### DIFF
--- a/Shaadi.xcodeproj/project.pbxproj
+++ b/Shaadi.xcodeproj/project.pbxproj
@@ -491,7 +491,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Shaadi/Preview Content\"";
-				DEVELOPMENT_TEAM = WR5H634DWJ;
+				DEVELOPMENT_TEAM = 63N9M44LL4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Shaadi/Info.plist;
@@ -506,7 +506,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rutik.Shaadi;
+				PRODUCT_BUNDLE_IDENTIFIER = com.internlabs.iOSProjectShaadi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -522,7 +522,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Shaadi/Preview Content\"";
-				DEVELOPMENT_TEAM = WR5H634DWJ;
+				DEVELOPMENT_TEAM = 63N9M44LL4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Shaadi/Info.plist;
@@ -537,7 +537,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rutik.Shaadi;
+				PRODUCT_BUNDLE_IDENTIFIER = com.internlabs.iOSProjectShaadi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Shaadi/Assets.xcassets/flamingoColor.colorset/Contents.json
+++ b/Shaadi/Assets.xcassets/flamingoColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "75",
+          "green" : "75",
+          "red" : "239"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Shaadi/Assets.xcassets/grayColor.colorset/Contents.json
+++ b/Shaadi/Assets.xcassets/grayColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "244",
+          "green" : "244",
+          "red" : "244"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Shaadi/View/AuthenticationView.swift
+++ b/Shaadi/View/AuthenticationView.swift
@@ -48,18 +48,26 @@ struct AuthenticationView: View {
                             .frame(width: 50, height: 50)
                             .background(
                                 RoundedRectangle(cornerRadius: 30)
-                                    .stroke(otp[index].isEmpty ? Color.gray : Color.red, lineWidth: 1)
+                                    .stroke(focusedField == index ? Color("flamingoColor") : Color("grayColor"), lineWidth: 1)
                             )
                             .multilineTextAlignment(.center)
                             .keyboardType(.numberPad)
                             .focused($focusedField, equals: index)
-                            .onChange(of: otp[index]) { newValue in
-                                // Auto-focus on the next field when a digit is entered
+                            .onAppear(perform: {
+                                focusedField = 0
+                            })
+                            .onChange(of: otp[index]) { _, newValue in
                                 if newValue.count == 1 {
+                                    // Auto-focus on the next field when a digit is entered
                                     if index < 3 {
                                         focusedField = index + 1
                                     } else {
                                         focusedField = nil
+                                    }
+                                } else if newValue.isEmpty {
+                                    // Auto-focus on the previous field when text is deleted
+                                    if index > 0 {
+                                        focusedField = index - 1
                                     }
                                 }
                             }

--- a/Shaadi/View/FinalAuthenticationView.swift
+++ b/Shaadi/View/FinalAuthenticationView.swift
@@ -46,17 +46,26 @@ struct FinalAuthenticationView: View {
                             .frame(width: 50, height: 50)
                             .background(
                                 RoundedRectangle(cornerRadius: 30)
-                                    .stroke(otp[index].isEmpty ? Color.gray : Color.red, lineWidth: 1)
+                                    .stroke(focusedField == index ? Color("flamingoColor") : Color("grayColor"), lineWidth: 1)
                             )
                             .multilineTextAlignment(.center)
                             .keyboardType(.numberPad)
                             .focused($focusedField, equals: index)
-                            .onChange(of: otp[index]) { newValue in
+                            .onAppear(perform: {
+                                focusedField = 0
+                            })
+                            .onChange(of: otp[index]) { _, newValue in
                                 if newValue.count == 1 {
+                                    // Auto-focus on the next field when a digit is entered
                                     if index < 3 {
                                         focusedField = index + 1
                                     } else {
                                         focusedField = nil
+                                    }
+                                } else if newValue.isEmpty {
+                                    // Auto-focus on the previous field when text is deleted
+                                    if index > 0 {
+                                        focusedField = index - 1
                                     }
                                 }
                             }

--- a/Shaadi/View/RegistrationView.swift
+++ b/Shaadi/View/RegistrationView.swift
@@ -48,7 +48,7 @@ struct RegistrationView: View {
                     .background(Color(.systemGray6))
                     .cornerRadius(10)
                     .textContentType(.emailAddress)
-                
+                    .keyboardType(.emailAddress)
                 // MARK: PASSWORD
                 HStack {
                     if showPassword {


### PR DESCRIPTION
- Adjusted OTP textfield border color as per focused state. 
- Added respective border colours to assets. 
- Add ability to delete number and focus to previous textfield on OTP screen. 
- Changed keyboard type of email textfield in registration view. 

Refer the videos below for clarification👇
Before ->
![Watch the video](https://github.com/user-attachments/assets/d70ac679-e926-42b8-bf4d-08fc8c649084)

After ->
![Watch the video](https://github.com/user-attachments/assets/2db680a0-8b6f-4e24-a23a-f342da4d2a8b)

